### PR TITLE
Removed perfpublisher from Jenkins plugins

### DIFF
--- a/files/plugins.txt
+++ b/files/plugins.txt
@@ -124,7 +124,6 @@ packer
 pam-auth
 Parameterized-Remote-Trigger
 parameterized-trigger
-perfpublisher
 permissive-script-security
 pipeline-aggregator-view
 pipeline-aws


### PR DESCRIPTION
This is due to security warnings:
Performance Publisher Plugin 8.09 and earlier does not configure its XML parser to prevent XML external entity (XXE) attacks.

This allows attackers able to control PerfPublisher report files to have Jenkins parse a crafted XML document that uses external entities for extraction of secrets from the Jenkins controller or server-side request forgery
