### PR TITLE
removed deprecated plugin

### DIFF
--- a/deployment/base/ingress.yml
+++ b/deployment/base/ingress.yml
@@ -13,6 +13,8 @@ metadata:
     nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
     nginx.ingress.kubernetes.io/configuration-snippet: |
+      proxy_set_header X-Forwarded-Proto $scheme;
+      proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
       server_tokens off;
       location /metrics {
         deny all;

--- a/files/plugins.txt
+++ b/files/plugins.txt
@@ -1,4 +1,3 @@
-ace-editor
 active-directory
 all-changes
 amazon-ecr


### PR DESCRIPTION
Reference: https://github.com/jenkins-infra/docker-jenkins-lts/pull/679
This plugin has been deprecated and is safe to remove as upstream Jenkins has removed pligin dependency for its UI
