### PR TITLE
removed convert-to-pipeline due to security warnings

### DIFF
--- a/files/plugins.txt
+++ b/files/plugins.txt
@@ -56,7 +56,6 @@ command-launcher
 conditional-buildstep
 config-file-provider
 configuration-as-code
-convert-to-pipeline
 credentials
 credentials-binding
 crowd2


### PR DESCRIPTION
The reason for this change is convert To Pipeline Plugin 1.0 and earlier uses basic string concatenation to convert Freestyle projects' Build Environment, Build Steps, and Post-build Actions to the equivalent Pipeline step invocations.

This allows attackers able to configure Freestyle projects to prepare a crafted configuration that injects Pipeline script code into the (unsandboxed) Pipeline resulting from a conversion by Convert To Pipeline Plugin. If an administrator converts the Freestyle project to a Pipeline, the script will be pre-approved
