### PR TITLE
chore(k8s): bump deployment image tag

### DIFF
--- a/deployment/base/jenkins.yml
+++ b/deployment/base/jenkins.yml
@@ -30,7 +30,7 @@ spec:
           type: RuntimeDefault
       containers:
         - name: jenkins
-          image: docker.io/saidsef/alpine-jenkins-dockerfile:v2024.04
+          image: docker.io/saidsef/alpine-jenkins-dockerfile:v2026.06
           imagePullPolicy: Always
           ports:
             - protocol: TCP

--- a/deployment/kustomization.yml
+++ b/deployment/kustomization.yml
@@ -12,4 +12,4 @@ commonAnnotations:
 images:
 - name: jenkins
   newName: docker.io/saidsef/alpine-jenkins-dockerfile
-  newTag: v2024.04
+  newTag: v2026.06


### PR DESCRIPTION
Updates the Jenkins image tag in the Kustomize manifests from v2024.04 to v2026.06, the latest released tag.

Changes:
- deployment/base/jenkins.yml: StatefulSet container image set to v2026.06
- deployment/kustomization.yml: images newTag set to v2026.06 (was previously floating on an unpinned value)

Both manifests now point at the same pinned tag so deployments are reproducible.